### PR TITLE
Update ons_node_start.sh

### DIFF
--- a/ons-bmc-1.0-master/ons_node_start.sh
+++ b/ons-bmc-1.0-master/ons_node_start.sh
@@ -3,6 +3,7 @@
 TMP=/tmp/ons
 mkdir -p $TMP/log
 
+export MALLOC_ARENA_MAX=1
 nohup java -Xmx256m -Xms256m -jar $KVHOME/lib/kvstore.jar start -root $KVROOT >$TMP/log/kvstore.log 2>&1 </dev/null &
 
 exit 0


### PR DESCRIPTION
Setting MALLOC_ARENA_MAX environment variable best practice according to ONDB Administration Guide.