### PR TITLE
Live Developer Lab - V0 fix

### DIFF
--- a/demo-events/live-developer-lab/serverless-with-nosql-database-and-functions/workshops/freetier/index.html
+++ b/demo-events/live-developer-lab/serverless-with-nosql-database-and-functions/workshops/freetier/index.html
@@ -8,19 +8,19 @@
     <meta name="description" content="Oracle LiveLabs gives you access to Oracle's products to run a wide variety of labs and workshops; allowing you to experience our best technology, live!">
     <title>Oracle LiveLabs</title>
 
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/jquery-1.11.0.min.js"></script>
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/jquery-ui-1.10.4.custom.js"></script>
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/main.min.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/jquery-1.11.0.min.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/jquery-ui-1.10.4.custom.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/main.min.js"></script>
 
-    <link rel="stylesheet" href="https://oracle.github.io/learning-library/common/redwood-hol/css/style.min.css" />
-    <link rel="shortcut icon" href="https://oracle.github.io/learning-library/common/redwood-hol/img/favicon.ico" />
+    <link rel="stylesheet" href="https://oracle-livelabs.github.io/common/redwood-hol/css/style.min.css" />
+    <link rel="shortcut icon" href="https://oracle-livelabs.github.io/common/redwood-hol/img/favicon.ico" />
 </head>
 
 <body>
     <header class="hol-Header" role="banner">
         <div class="hol-Header-wrap">
             <div class="hol-Header-logo"><span>Oracle LiveLabs</span></div>
-            <a href="https://bit.ly/golivelabs" target="_blank" id="livelabs" title="Oracle LiveLabs"></a>
+            <a href="https://developer.oracle.com/livelabs" target="_blank" id="livelabs" title="Oracle LiveLabs"></a>
             <div class="hol-Header-actions">
                 <button id="openNav" class="hol-Header-button hol-Header-button--menu rightNav" aria-label="Open Menu"
                     title="Open Menu">

--- a/demo-events/live-developer-lab/serverless-with-nosql-database-and-functions/workshops/livelabs/index.html
+++ b/demo-events/live-developer-lab/serverless-with-nosql-database-and-functions/workshops/livelabs/index.html
@@ -8,20 +8,19 @@
     <meta name="description" content="Oracle LiveLabs gives you access to Oracle's products to run a wide variety of labs and workshops; allowing you to experience our best technology, live!">
     <title>Oracle LiveLabs</title>
 
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/jquery-1.11.0.min.js"></script>
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/jquery-ui-1.10.4.custom.js"></script>
-    <script src="main.21.1.1.js"></script>
-    <script src="https://oracle.github.io/learning-library/common/redwood-hol/js/main.min.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/jquery-1.11.0.min.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/jquery-ui-1.10.4.custom.js"></script>
+    <script src="https://oracle-livelabs.github.io/common/redwood-hol/js/main.min.js"></script>
 
-    <link rel="stylesheet" href="https://oracle.github.io/learning-library/common/redwood-hol/css/style.min.css" />
-    <link rel="shortcut icon" href="https://oracle.github.io/learning-library/common/redwood-hol/img/favicon.ico" />
+    <link rel="stylesheet" href="https://oracle-livelabs.github.io/common/redwood-hol/css/style.min.css" />
+    <link rel="shortcut icon" href="https://oracle-livelabs.github.io/common/redwood-hol/img/favicon.ico" />
 </head>
 
 <body>
     <header class="hol-Header" role="banner">
         <div class="hol-Header-wrap">
             <div class="hol-Header-logo"><span>Oracle LiveLabs</span></div>
-            <a href="https://bit.ly/golivelabs" target="_blank" id="livelabs" title="Oracle LiveLabs"></a>
+            <a href="https://developer.oracle.com/livelabs" target="_blank" id="livelabs" title="Oracle LiveLabs"></a>
             <div class="hol-Header-actions">
                 <button id="openNav" class="hol-Header-button hol-Header-button--menu rightNav" aria-label="Open Menu"
                     title="Open Menu">


### PR DESCRIPTION
**Live Developer Lab**

Using the new template index.html in the `workshops` directory

> https://oracle.github.io/learning-library vs. https://oracle-livelabs.github.io

During the  Live Webinar - Live Developer Lab, an attendee was not able to access the instructions

Signed-off-by: [dario.vega@oracle.com](mailto:dario.vega@oracle.com)