### PR TITLE
examples-nosql-node-sdk/my-first-nest-rest-app - nestjs/with-nosql

### DIFF
--- a/examples-nosql-node-sdk/my-first-nest-rest-app/package.json
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^9.0.0",
+    "oracle-nosqldb": "^5.3.3",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0"

--- a/examples-nosql-node-sdk/my-first-nest-rest-app/src/main.ts
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/src/main.ts
@@ -1,7 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { NoSQLService } from './nosql.service';
 
 async function bootstrap() {
+
+  await  NoSQLService.initDb();
+  await  NoSQLService.createDbTable();
+
+
   const app = await NestFactory.create(AppModule);
   await app.listen(3000);
 }

--- a/examples-nosql-node-sdk/my-first-nest-rest-app/src/nosql.service.ts
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/src/nosql.service.ts
@@ -38,7 +38,6 @@ export class NoSQLService {
          let offset = +params.page*+params.limit;
          statement = statement + " OFFSET " + offset;
       }
-      console.log(statement);
 
       for await(const res of this.getInstance().getConnection().queryIterable(statement)) {
         rows.push.apply(rows, res.rows);

--- a/examples-nosql-node-sdk/my-first-nest-rest-app/src/nosql.service.ts
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/src/nosql.service.ts
@@ -1,0 +1,126 @@
+import { NoSQLClient, ServiceType, QueryResult, CapacityMode } from 'oracle-nosqldb';
+
+export class NoSQLService {
+
+    connection: any;
+    private static instance: NoSQLService;
+
+    private constructor() {
+        this.creatDbConnection();
+    }
+
+    static async initDb() {
+        if (!this.instance) {
+            this.instance = new NoSQLService();
+        }
+        return this.instance;
+    }
+
+    static getInstance() {
+        return this.instance;
+    }
+
+    getConnection() {
+        return this.connection;
+    }
+
+    static async findAll(tablename, params) {
+      let rows = [];
+      let statement = `SELECT * FROM ${tablename}`;
+
+      if (params.where )
+         statement = statement + " WHERE " + params.where;
+      if (params.orderby )
+         statement = statement + " ORDER BY " + params.orderby;
+      if (params.limit)
+         statement = statement + " LIMIT " + params.limit;
+      if (params.page && params.limit) {
+         let offset = +params.page*+params.limit;
+         statement = statement + " OFFSET " + offset;
+      }
+      console.log(statement);
+
+      for await(const res of this.getInstance().getConnection().queryIterable(statement)) {
+        rows.push.apply(rows, res.rows);
+      }
+      return rows;
+    }
+
+    static async findOne (tablename, id) {
+        const result = await this.getInstance().getConnection().get(tablename, { id })
+        if (result.row)
+          return result.row;
+        else
+          return {}
+    }
+
+    static async create (tablename, record) {
+        const result = await this.getInstance().getConnection().put(tablename, record );
+        return { result: result};
+    }
+
+    static async update (tablename, id,  record) {
+        const result = await this.getInstance().getConnection().putIfPresent(tablename, Object.assign(record, {id}) );
+        return { result: result};
+    }
+
+    static async remove (tablename, id) {
+        const result = await this.getInstance().getConnection().delete(tablename, { id });
+        return { result: result};
+    }
+
+    static async createDbTable() {
+       const createDDL = 'CREATE TABLE IF NOT EXISTS users (id String, info JSON , PRIMARY KEY (id))';
+       // readUnits, writeUnits, storageGB using same values as for Always free
+       let resTab = await this.getInstance().getConnection().tableDDL(createDDL, {
+         tableLimits: {
+            // mode: CapacityMode.ON_DEMAND,
+            mode: CapacityMode.PROVISIONED,
+            readUnits: 50,
+            writeUnits: 50,
+            storageGB: 25
+         }
+         , complete: true
+       }) ;
+       console.log('  Creating table %s', resTab.tableName);
+       console.log('  Table state: %s', resTab.tableState.name);
+    }
+
+    private creatDbConnection() {
+       switch(process.env.NOSQL_ServiceType) {
+       case 'useInstancePrincipal':
+           this.connection = new NoSQLClient({
+               serviceType: ServiceType.CLOUD,
+               region: process.env.NOSQL_REGION ,
+               compartment:process.env.NOSQL_COMPID,
+               auth: {
+                 iam: {
+                     useInstancePrincipal: true
+                 }
+               }
+           });
+           break;
+       case 'useDelegationToken':
+           this.connection = new NoSQLClient({
+               serviceType: ServiceType.CLOUD,
+               region: process.env.NOSQL_REGION ,
+               compartment:process.env.NOSQL_COMPID,
+               auth: {
+                 iam: {
+                     useInstancePrincipal: true,
+                     delegationTokenProvider: process.env.OCI_DELEGATION_TOKEN_FILE
+                 }
+               }
+           });
+           break;
+       default:
+          // on-premise non-secure configuration or Cloud Simulator
+          this.connection = new NoSQLClient({
+               serviceType: ServiceType.KVSTORE,
+               endpoint: process.env.NOSQL_ENDPOINT + ":" + process.env.NOSQL_PORT
+           });
+       }
+    }
+
+}
+

--- a/examples-nosql-node-sdk/my-first-nest-rest-app/src/users/users.controller.ts
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -13,22 +13,22 @@ export class UsersController {
   }
 
   @Get()
-  findAll() {
-    return this.usersService.findAll();
+  findAll(@Query() params) {
+    return this.usersService.findAll(params);
   }
 
   @Get(':id')
   findOne(@Param('id') id: string) {
-    return this.usersService.findOne(+id);
+    return this.usersService.findOne(id);
   }
 
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(+id, updateUserDto);
+    return this.usersService.update(id, updateUserDto);
   }
 
   @Delete(':id')
   remove(@Param('id') id: string) {
-    return this.usersService.remove(+id);
+    return this.usersService.remove(id);
   }
 }

--- a/examples-nosql-node-sdk/my-first-nest-rest-app/src/users/users.service.ts
+++ b/examples-nosql-node-sdk/my-first-nest-rest-app/src/users/users.service.ts
@@ -1,26 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { NoSQLService } from '.././nosql.service';
+
 
 @Injectable()
 export class UsersService {
-  create(createUserDto: CreateUserDto) {
-    return 'This action adds a new user';
+  async create(createUserDto: CreateUserDto) {
+    return await NoSQLService.create('users', createUserDto);
   }
 
-  findAll() {
-    return `This action returns all users`;
+  async findAll(params) {
+    return await NoSQLService.findAll('users', params);
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
+  async findOne(id: string) {
+    return await NoSQLService.findOne('users', id);
   }
 
-  update(id: number, updateUserDto: UpdateUserDto) {
-    return `This action updates a #${id} user`;
+  async update(id: string, updateUserDto: UpdateUserDto) {
+    return await NoSQLService.update('users', id, updateUserDto);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} user`;
+  async remove(id: string) {
+    return await NoSQLService.remove('users', id);
   }
 }


### PR DESCRIPTION
This PR (`nestjs/with-nosql`) adds Oracle NoSQL support to the previous version (`nestjs/first-steps`) example by

    adding the `nosql.service.ts` (class NoSQLService)
    modifying the `main.ts` - connection to Oracle NoSQL database
    modifying the `users.service.ts` to call Oracle NoSQL database

The previous PR (`nestjs/first-steps`) built the application using the following nest commands - first steps tutorial:

    nest new my-first-nest-rest-app
    nest g resource users

By creating 2 pull requests, we can highlight the difference between `nestjs/first-steps` and `nestjs/with-nosql`

- see https://github.com/oracle/nosql-examples/pull/88/files

Signed-off-by: [dario.vega@oracle.com](mailto:dario.vega@oracle.com)