### PR TITLE
examples-nosql-java-sdk/helidon-quickstart-se-with-nosql

### DIFF
--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/README.md
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/README.md
@@ -6,23 +6,62 @@ Sample Helidon SE project that includes multiple REST operations.
 
 With JDK11+
 ```bash
+
+# modify src/main/resources/application.yaml
+
+cat src/main/resources/application.yaml
+
+app:
+  greeting: "Hello"
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+nosql:
+  OCI_CLI_AUTH: instance_principal
+  region: us-ashburn-1
+  compartment-id: ocid1.compartment.oc1..aaaaaaaa4mlehopmvdluv2wjcdp4tnh2ypjz3nhhpahb4ss7yvxaa3be3diq
+
+ 
 mvn package
 java -jar target/helidon-quickstart-se.jar
 ```
 
 ## Exercise the application
 
+
 ```
+curl -X PUT -H "Content-Type: application/json" -d '{"id":1, "message" : "Hola"}' http://localhost:8080/greet/greeting
+curl -X PUT -H "Content-Type: application/json" -d '{"id":2, "message" : "Bonjour"}' http://localhost:8080/greet/greeting
+curl -X PUT -H "Content-Type: application/json" -d '{"id":3, "message" : "Hello"}' http://localhost:8080/greet/greeting
+
 curl -X GET http://localhost:8080/greet
-{"message":"Hello World!"}
+[
+  {
+    "id": 3,
+    "message": "Helll"
+  },
+  {
+    "id": 2,
+    "message": "Bonjour"
+  },
+  {
+    "id": 1,
+    "message": "Hola"
+  }
+]
 
-curl -X GET http://localhost:8080/greet/Joe
-{"message":"Hello Joe!"}
 
-curl -X PUT -H "Content-Type: application/json" -d '{"greeting" : "Hola"}' http://localhost:8080/greet/greeting
+curl -X GET http://localhost:8080/greet/1
+{"id":1,"message":"Hola"}
 
-curl -X GET http://localhost:8080/greet/Jose
-{"message":"Hola Jose!"}
+curl -X GET http://localhost:8080/greet/2
+{"id":2,"message":"Bonjour"}
+
+curl -X GET http://localhost:8080/greet/3
+{"id":3,"message":"Hello"}
+
 ```
 
 ## Try health and metrics

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/pom.xml
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.media</groupId>
-            <artifactId>helidon-media-jsonp</artifactId>
+            <artifactId>helidon-media-jsonb</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.config</groupId>
@@ -52,6 +52,12 @@
             <groupId>io.helidon.webclient</groupId>
             <artifactId>helidon-webclient</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.oracle.nosql.sdk/nosqldriver -->
+        <dependency>
+          <groupId>com.oracle.nosql.sdk</groupId>
+          <artifactId>nosqldriver</artifactId>
+          <version>5.3.7</version>
         </dependency>
     </dependencies>
 

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Greet.java
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Greet.java
@@ -1,0 +1,34 @@
+package io.helidon.examples.quickstart.se;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Greet {
+    private Integer id;
+    private String message;
+
+    public Integer  getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return "Greet [id=" + id + " message=" + message +  "]";
+    }
+
+}

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/GreetRepo.java
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/GreetRepo.java
@@ -1,0 +1,12 @@
+package io.helidon.examples.quickstart.se;
+
+import java.util.List;
+
+public interface GreetRepo {
+    //void createTable();
+
+    Greet save(Greet greet);
+    Greet findById(Integer id);
+    List<Greet> findAll() ;
+
+}

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/GreetRepoImpl.java
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/GreetRepoImpl.java
@@ -1,0 +1,190 @@
+package io.helidon.examples.quickstart.se;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.DeleteRequest;
+import oracle.nosql.driver.ops.GetRequest;
+import oracle.nosql.driver.ops.GetResult;
+import oracle.nosql.driver.ops.PrepareRequest;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.PutRequest;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.TableRequest;
+import oracle.nosql.driver.ops.QueryIterableResult;
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.LongValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.TimestampValue;
+import oracle.nosql.driver.values.StringValue;
+import oracle.nosql.driver.ops.TableLimits;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+import javax.json.Json;
+import javax.json.bind.Jsonb;
+import javax.json.bind.JsonbBuilder;
+
+
+
+public class GreetRepoImpl implements GreetRepo {
+    public static final String KV_JSON = "kv_json_";
+    private static final String TABLE_NAME = "GreetTableJSON";
+    private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS "
+        + TABLE_NAME + "(id INTEGER, kv_json_ JSON, " +
+        "PRIMARY KEY(id))";
+    public static final String SELECT_ALL = "select * from " + TABLE_NAME + " t";
+    public static final String COUNT_ALL = "select count(*) as cnt from " + TABLE_NAME;
+    public static final String DELETE_ALL = "delete from " + TABLE_NAME;
+
+    private final NoSQLHandle client;
+    private final Map<String, PreparedStatement> prepMap = new HashMap<>();
+
+    GreetRepoImpl(NoSQLHandle client) {
+        this.client = client;
+        createTable();
+    }
+
+    /**
+     * Creates the required table if not previously created.
+     */
+    private void createTable() {
+        TableRequest req = new TableRequest();
+        req.setStatement(CREATE_TABLE)
+                .setTableLimits(new TableLimits(10, 10, 10));
+        client.doTableRequest(req, 20000, 1000);
+    }
+
+    public Greet save(Greet greet) {
+        PutRequest req = new PutRequest();
+        req.setTableName(TABLE_NAME);
+        MapValue row = toMapValue(greet);
+        req.setValue(row);
+        //PutResult res =
+        client.put(req);
+
+        return greet;
+    }
+
+    public Greet findById(Integer greetId) {
+        GetRequest req = new GetRequest();
+        req.setTableName(TABLE_NAME);
+        MapValue key = new MapValue()
+                .put("id", greetId); 
+        req.setKey(key);
+        GetResult res = client.get(req);
+        MapValue value = res.getValue();
+        if (value == null) {
+            return null;
+        }
+
+        Greet result = fromMapValue (value);
+        return result;
+    }
+
+    public List<Greet> findAll() {
+
+        Map<String, String> pageable = new HashMap<>();
+        pageable.put("order", "ORDER BY id DESC");
+        pageable.put("limit", "10");
+        pageable.put("offset", "0");
+
+        String where = " ";
+
+        Map<String, FieldValue> params = new HashMap<>();
+        //params.put("$param", new StringValue(".*" + name + ".*"));
+
+        return  executeQuery(pageable, params, where);
+
+    }
+
+
+    private List<Greet> executeQuery(Map<String, String > pageable, Map<String, FieldValue> params, String where) {
+
+        String sql = sqlBuilder(pageable, params, where);
+
+        PreparedStatement preparedStatement = ensurePrepared(sql)
+                .copyStatement();
+        QueryRequest queryRequest = new QueryRequest()
+                .setPreparedStatement(preparedStatement);
+
+        params.forEach((k, v) -> preparedStatement.setVariable(k, v));
+
+        List<Greet> listGreet = new ArrayList<Greet>();
+        try (QueryIterableResult results = client.queryIterable(queryRequest)) {
+                for (MapValue res : results) {
+                    Greet result = fromMapValue (res);
+                    listGreet.add(result);
+                }
+        }
+
+        return listGreet;
+    }
+
+
+
+    private static String sqlBuilder(Map<String, String > pageable, Map<String, FieldValue> params, String where) {
+
+        String sql = SELECT_ALL + (where == null ? "" : where);
+        sql = sql + pageable.get("order");
+        sql += " LIMIT $kv_limit_ OFFSET $kv_offset_";
+
+        params.put("$kv_limit_",  new LongValue(pageable.get("limit")) );
+        params.put("$kv_offset_", new LongValue(pageable.get("offset")) );
+
+        String declare = params.entrySet()
+            .stream()
+            .map((entry) -> entry.getKey() + " " + entry.getValue().getType().name())
+            .collect(Collectors.joining("; ", "DECLARE ", "; "));
+
+        sql = declare + " " + sql;
+
+        return sql;
+    }
+
+
+    // Following methods transform POJO key/entity to/from MapValue
+    private MapValue toMapValue(Greet greet) {
+       Jsonb jsonb = JsonbBuilder.create();
+       String result = jsonb.toJson(greet);
+       MapValue row = new MapValue()
+                .put("id", greet.getId())
+                .putFromJson("kv_json_", result, null);
+       return row;
+    }
+
+
+    private Greet fromMapValue(MapValue value) {
+        if (value == null) {
+            return null;
+        }
+
+        Jsonb jsonb = JsonbBuilder.create();
+
+        Greet result = new Greet();
+        result = jsonb.fromJson(value.get("kv_json_").toJson(), Greet.class);
+        result.setId(value.getInt("id"));
+        return result;
+    }
+
+
+    // Cache prepared statements
+    private PreparedStatement ensurePrepared(String statement) {
+        PreparedStatement preparedStatement = prepMap.get(statement);
+        if (preparedStatement == null) {
+            synchronized (prepMap) {
+                preparedStatement = client.prepare(
+                    new PrepareRequest().setStatement(statement))
+                    .getPreparedStatement();
+                prepMap.put(statement, preparedStatement);
+            }
+        }
+        return preparedStatement;
+    }
+}

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -96,7 +96,7 @@ public final class Main {
                 .register("/greet", greetService)
                 .build();
     }
-
+    private static NoSQLHandle getNoSQLConnection(Config config) {
         String OCI_CLI_AUTH = config.get("nosql").get("OCI_CLI_AUTH").asString().get();
         SignatureProvider authProvider = null;
         try {

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Main.java
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/java/io/helidon/examples/quickstart/se/Main.java
@@ -6,10 +6,17 @@ import io.helidon.common.reactive.Single;
 import io.helidon.config.Config;
 import io.helidon.health.HealthSupport;
 import io.helidon.health.checks.HealthChecks;
-import io.helidon.media.jsonp.JsonpSupport;
+//import io.helidon.media.jsonp.JsonpSupport;
+import io.helidon.media.jsonb.JsonbSupport;
 import io.helidon.metrics.MetricsSupport;
 import io.helidon.webserver.Routing;
 import io.helidon.webserver.WebServer;
+
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.NoSQLHandleConfig;
+import oracle.nosql.driver.NoSQLHandleFactory;
+import oracle.nosql.driver.Region;
+import oracle.nosql.driver.iam.SignatureProvider;
 
 /**
  * The application main class.
@@ -44,7 +51,8 @@ public final class Main {
 
         WebServer server = WebServer.builder(createRouting(config))
                 .config(config.get("server"))
-                .addMediaSupport(JsonpSupport.create())
+                //.addMediaSupport(JsonpSupport.create())
+                .addMediaSupport(JsonbSupport.create())
                 .build();
 
         Single<WebServer> webserver = server.start();
@@ -72,15 +80,32 @@ public final class Main {
     private static Routing createRouting(Config config) {
 
         MetricsSupport metrics = MetricsSupport.create();
-        GreetService greetService = new GreetService(config);
+        
+        NoSQLHandle client = getNoSQLConnection(config); // 1) Use of NoSQLHandle
+        // 2) No Metrics support
+        // 3) No Health support
+        GreetService greetService = new GreetService(config, new GreetRepoImpl(client)); // 4) Initialize GreetRepoImpl with NoSQLHandle
         HealthSupport health = HealthSupport.builder()
                 .addLiveness(HealthChecks.healthChecks())   // Adds a convenient set of checks
                 .build();
 
-        return Routing.builder()
+        return Routing.builder() // 5) Register the services in Routing
                 .register(health)                   // Health at "/health"
                 .register(metrics)                  // Metrics at "/metrics"
                 .register("/greet", greetService)
                 .build();
     }
+
+    private static NoSQLHandle getNoSQLConnection(Config config) {
+
+        System.out.println(config.get("nosql").get("OCI_CLI_AUTH").asString());
+        System.out.println(config.get("nosql").get(".region").asString());
+        System.out.println(config.get("nosql").get("compartment-id").asString());
+
+        SignatureProvider authProvider = SignatureProvider.createWithInstancePrincipal();
+        NoSQLHandleConfig NoSQLconfig = new NoSQLHandleConfig(config.get("nosql").get(".region").asString().get(), authProvider);
+        NoSQLconfig.setDefaultCompartment(config.get("nosql").get("compartment-id").asString().get());
+        return( NoSQLHandleFactory.createNoSQLHandle(NoSQLconfig) );
+    }
+
 }

--- a/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/resources/application.yaml
+++ b/examples-nosql-java-sdk/helidon-quickstart-se-with-nosql/src/main/resources/application.yaml
@@ -5,3 +5,8 @@ app:
 server:
   port: 8080
   host: 0.0.0.0
+
+nosql:
+  OCI_CLI_AUTH: instance_principal
+  region: us-ashburn-1
+  compartment-id: ocid1.compartment.oc1..aaaaaaaa4mlehopmvdluv2wjcdp4tnh2ypjz3nhhpahb4ss7yvxaa3be3diq


### PR DESCRIPTION
In this PR, we will provide an example using Oracle NoSQL based on this `helidon-quickstart-se`

The previous PR (Helidon SE Quickstart) showed the `helidon-quickstart-se` - using version 2.5.4
```

mvn -U archetype:generate -DinteractiveMode=false \
    -DarchetypeGroupId=io.helidon.archetypes \
    -DarchetypeArtifactId=helidon-quickstart-se \
    -DarchetypeVersion=2.5.4 \
    -DgroupId=io.helidon.examples \
    -DartifactId=helidon-quickstart-se \
    -Dpackage=io.helidon.examples.quickstart.se
```

By creating 2 pull requests, we can highlight the difference between both

https://github.com/oracle/nosql-examples/pull/90/files

Signed-off-by: [dario.vega@oracle.com](mailto:dario.vega@oracle.com)
