### PR TITLE
Removed exit function

### DIFF
--- a/examples-nosql-python-sdk/sqlexamples/AddBagData.py
+++ b/examples-nosql-python-sdk/sqlexamples/AddBagData.py
@@ -387,7 +387,6 @@ def main():
    insert_record(handle,'BaggageInfo',bag4)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/AddData.py
+++ b/examples-nosql-python-sdk/sqlexamples/AddData.py
@@ -339,7 +339,6 @@ def main():
    insert_record(handle,'stream_acct',acct3)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/AlterTable.py
+++ b/examples-nosql-python-sdk/sqlexamples/AlterTable.py
@@ -70,7 +70,6 @@ def main():
    drop_table(handle)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/CreateTable.py
+++ b/examples-nosql-python-sdk/sqlexamples/CreateTable.py
@@ -55,7 +55,6 @@ def main():
    create_table(handle)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
    main()

--- a/examples-nosql-python-sdk/sqlexamples/GroupSortData.py
+++ b/examples-nosql-python-sdk/sqlexamples/GroupSortData.py
@@ -411,7 +411,6 @@ def main():
    fetch_data(handle,groupsortlimit_stmt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/Indexes.py
+++ b/examples-nosql-python-sdk/sqlexamples/Indexes.py
@@ -74,7 +74,6 @@ def main():
    drop_index(handle)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
    main()

--- a/examples-nosql-python-sdk/sqlexamples/ModifyData.py
+++ b/examples-nosql-python-sdk/sqlexamples/ModifyData.py
@@ -481,7 +481,6 @@ def main():
    delete_rows(handle,del_stmt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/MultiDataOps.py
+++ b/examples-nosql-python-sdk/sqlexamples/MultiDataOps.py
@@ -86,7 +86,6 @@ def main():
    fetch_rowCnt(handle,sqlstmt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/MultiWrite.py
+++ b/examples-nosql-python-sdk/sqlexamples/MultiWrite.py
@@ -136,7 +136,6 @@ def main():
    insert_record(handle,'ticket.bagInfo.flightLegs',data3)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
    main()

--- a/examples-nosql-python-sdk/sqlexamples/Namespaces.py
+++ b/examples-nosql-python-sdk/sqlexamples/Namespaces.py
@@ -40,7 +40,6 @@ def main():
    drop_ns(handle)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/QueryData.py
+++ b/examples-nosql-python-sdk/sqlexamples/QueryData.py
@@ -363,7 +363,6 @@ def main():
    fetch_data(handle,sqlstmt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/Regions.py
+++ b/examples-nosql-python-sdk/sqlexamples/Regions.py
@@ -72,7 +72,6 @@ def main():
    drop_region(handle)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/SQLExpressions.py
+++ b/examples-nosql-python-sdk/sqlexamples/SQLExpressions.py
@@ -431,7 +431,6 @@ def main():
    fetch_data(handle,seq_trn_expr)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/SQLFunctions.py
+++ b/examples-nosql-python-sdk/sqlexamples/SQLFunctions.py
@@ -418,7 +418,6 @@ def main():
    fetch_data(handle,string_func3)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/SQLOperators.py
+++ b/examples-nosql-python-sdk/sqlexamples/SQLOperators.py
@@ -418,7 +418,6 @@ def main():
    fetch_data(handle,existsope_stmt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+   
 if __name__ == "__main__":
     main()

--- a/examples-nosql-python-sdk/sqlexamples/TableJoins.py
+++ b/examples-nosql-python-sdk/sqlexamples/TableJoins.py
@@ -139,7 +139,6 @@ def main():
    fetch_data(handle,sql_stmt_nt)
    if handle is not None:
       handle.close()
-   os._exit(0)
-
+  
 if __name__ == "__main__":
    main()


### PR DESCRIPTION
Removed exit() function from all python code examples