### PR TITLE
Inner Join

### DIFF
--- a/examples-nosql-dotnet-sdk/sqlexamples/TableJoins.cs
+++ b/examples-nosql-dotnet-sdk/sqlexamples/TableJoins.cs
@@ -153,11 +153,11 @@ namespace Oracle.NoSQL.SDK.Samples
             Console.WriteLine("Added a row to the {0} table",childTblName);
             await client.PutAsync(descTblName, FieldValue.FromJsonString(data3).AsMapValue);
             Console.WriteLine("Added a row to the {0} table",descTblName);
-            Console.WriteLine("Fetching data using Left Outer Joins: ");
+            Console.WriteLine("Fetching data using Left Outer Join: ");
             await fetchData(client,stmt_loj);
             Console.WriteLine("Fetching data using NESTED TABLES: ");
             await fetchData(client,stmt_nt);
-            Console.WriteLine("Fetching data using Inner Joins: ");
+            Console.WriteLine("Fetching data using Inner Join: ");
             await fetchData(client,stmt_ij);
          }
          catch (Exception ex) {

--- a/examples-nosql-dotnet-sdk/sqlexamples/TableJoins.cs
+++ b/examples-nosql-dotnet-sdk/sqlexamples/TableJoins.cs
@@ -74,6 +74,7 @@ namespace Oracle.NoSQL.SDK.Samples
                                        ""actionTime"" : ""2019-02-01T04:38:00Z""} ]}";
       private const string stmt_loj ="SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo";
       private const string stmt_nt ="SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))";
+      private const string stmt_ij ="SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo";
 
       //Get a connection handle for Oracle NoSQL Database Cloud Service
       private async static Task<NoSQLClient> getconnection_cloud()
@@ -156,6 +157,8 @@ namespace Oracle.NoSQL.SDK.Samples
             await fetchData(client,stmt_loj);
             Console.WriteLine("Fetching data using NESTED TABLES: ");
             await fetchData(client,stmt_nt);
+            Console.WriteLine("Fetching data using Inner Joins: ");
+            await fetchData(client,stmt_ij);
          }
          catch (Exception ex) {
             Console.WriteLine("Exception has occurred:\n{0}: {1}",

--- a/examples-nosql-go-sdk/sqlexamples/TableJoins.go
+++ b/examples-nosql-go-sdk/sqlexamples/TableJoins.go
@@ -244,10 +244,10 @@ func main() {
 	addData(client, err, regTableName, regtbl_data)
 	addData(client, err, childTableName, childtbl_data)
 	addData(client, err, descTableName, desctbl_data)
-	fmt.Println("Fetching data using Left Outer Joins")
+	fmt.Println("Fetching data using Left Outer Join")
 	fetchData(client, err, querystmt_loj)
 	fmt.Println("Fetching data using NESTED TABLES")
 	fetchData(client, err, querystmt_nt)
-	fmt.Println("Fetching data using Inner Joins")
+	fmt.Println("Fetching data using Inner Join")
 	fetchData(client, err, querystmt_ij)		
 }

--- a/examples-nosql-go-sdk/sqlexamples/TableJoins.go
+++ b/examples-nosql-go-sdk/sqlexamples/TableJoins.go
@@ -237,6 +237,7 @@ func main() {
    }`
 	querystmt_loj := "SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo"
 	querystmt_nt := "SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b)"
+	querystmt_ij := "SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo"	
 	createTable(client, err, regTableName, regtbl_crtstmt, "true")
 	createTable(client, err, childTableName, childtbl_crtstmt, "false")
 	createTable(client, err, descTableName, desctbl_crtstmt, "false")
@@ -247,4 +248,6 @@ func main() {
 	fetchData(client, err, querystmt_loj)
 	fmt.Println("Fetching data using NESTED TABLES")
 	fetchData(client, err, querystmt_nt)
+	fmt.Println("Fetching data using Inner Joins")
+	fetchData(client, err, querystmt_ij)		
 }

--- a/examples-nosql-java-sdk/sqlexamples/TableJoins.java
+++ b/examples-nosql-java-sdk/sqlexamples/TableJoins.java
@@ -114,6 +114,10 @@ public class TableJoins{
          String sql_stmt_nt ="SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))";
          /* fetching rows using nested tables*/
          fetchRows(handle,sql_stmt_nt);
+         System.out.println("Fetching data using Inner Joins:");
+         String sql_stmt_ij ="SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo";
+         /* fetching rows using nested tables*/
+         fetchRows(handle,sql_stmt_ij);			 
       } catch (Exception e) {
          System.err.print(e);
       } finally {

--- a/examples-nosql-java-sdk/sqlexamples/TableJoins.java
+++ b/examples-nosql-java-sdk/sqlexamples/TableJoins.java
@@ -108,13 +108,13 @@ public class TableJoins{
          writeRowData(handle,"ticket.bagInfo.flightLegs",data3);
          /* fetching rows using left outer joins*/
          String sql_stmt_loj ="SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo";
-         System.out.println("Fetching data using Left outer joins:");
+         System.out.println("Fetching data using Left outer join:");
          fetchRows(handle,sql_stmt_loj);
          System.out.println("Fetching data using NESTED TABLES:");
          String sql_stmt_nt ="SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))";
          /* fetching rows using nested tables*/
          fetchRows(handle,sql_stmt_nt);
-         System.out.println("Fetching data using Inner Joins:");
+         System.out.println("Fetching data using Inner Join:");
          String sql_stmt_ij ="SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo";
          /* fetching rows using nested tables*/
          fetchRows(handle,sql_stmt_ij);			 

--- a/examples-nosql-node-sdk/sqlexamples/javascript/TableJoins.js
+++ b/examples-nosql-node-sdk/sqlexamples/javascript/TableJoins.js
@@ -92,11 +92,11 @@ async function dotablejoins() {
       console.log("Wrote records in bagInfo table");
       let putResult2 = await handle.put(desctable_name, JSON.parse(data3));
       console.log("Wrote records in flightLegs table");
-      console.log("Fetching data using Left Outer Joins");
+      console.log("Fetching data using Left Outer Join");
       await fetchData(handle,stmt_loj);
       console.log("Fetching data using NESTED TABLES");
       await fetchData(handle,stmt_nt);
-      console.log("Fetching data using Inner Joins");
+      console.log("Fetching data using Inner Join");
       await fetchData(handle,stmt_ij);		  
    } catch (error ) {
       console.log(error);

--- a/examples-nosql-node-sdk/sqlexamples/javascript/TableJoins.js
+++ b/examples-nosql-node-sdk/sqlexamples/javascript/TableJoins.js
@@ -82,6 +82,7 @@ async function dotablejoins() {
       }`
       const stmt_loj = 'SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo';
       const stmt_nt = 'SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))';
+      const stmt_ij = 'SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo';	  
       await createTable(handle,regtbl_DDL,'true',table_name);
       await createTable(handle,childtbl_DDL,'false',childtable_name);
       await createTable(handle,desctbl_DDL,'false',desctable_name);
@@ -95,6 +96,8 @@ async function dotablejoins() {
       await fetchData(handle,stmt_loj);
       console.log("Fetching data using NESTED TABLES");
       await fetchData(handle,stmt_nt);
+      console.log("Fetching data using Inner Joins");
+      await fetchData(handle,stmt_ij);		  
    } catch (error ) {
       console.log(error);
    }

--- a/examples-nosql-node-sdk/sqlexamples/typescript/TableJoins.ts
+++ b/examples-nosql-node-sdk/sqlexamples/typescript/TableJoins.ts
@@ -116,11 +116,11 @@ async function dotablejoins() {
       console.log("Wrote records in bagInfo table");
       let putResult2 = await handle.put<DesctableInt>(desctable_name, JSON.parse(data3));
       console.log("Wrote records in flightLegs table");
-      console.log("Fetching data using Left Outer Joins");
+      console.log("Fetching data using Left Outer Join");
       await fetchData(handle,stmt_loj);
       console.log("Fetching data using NESTED TABLES");
       await fetchData(handle,stmt_nt);
-      console.log("Fetching data using Inner Joins");
+      console.log("Fetching data using Inner Join");
       await fetchData(handle,stmt_ij);		  
    } catch (error ) {
       console.log(error);

--- a/examples-nosql-node-sdk/sqlexamples/typescript/TableJoins.ts
+++ b/examples-nosql-node-sdk/sqlexamples/typescript/TableJoins.ts
@@ -106,6 +106,7 @@ async function dotablejoins() {
       }`
       const stmt_loj = 'SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo';
       const stmt_nt = 'SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))';
+      const stmt_ij = 'SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo';
       await createTable(handle,regtbl_DDL,true,table_name);
       await createTable(handle,childtbl_DDL,false,childtable_name);
       await createTable(handle,desctbl_DDL,false,desctable_name);
@@ -119,6 +120,8 @@ async function dotablejoins() {
       await fetchData(handle,stmt_loj);
       console.log("Fetching data using NESTED TABLES");
       await fetchData(handle,stmt_nt);
+      console.log("Fetching data using Inner Joins");
+      await fetchData(handle,stmt_ij);		  
    } catch (error ) {
       console.log(error);
    }

--- a/examples-nosql-python-sdk/sqlexamples/TableJoins.py
+++ b/examples-nosql-python-sdk/sqlexamples/TableJoins.py
@@ -137,6 +137,9 @@ def main():
    sql_stmt_nt='SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))'
    print('Fetching data using NESTED TABLES ')
    fetch_data(handle,sql_stmt_nt)
+   sql_stmt_ij='SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo'
+   print('Fetching data using Inner Joins ')
+   fetch_data(handle,sql_stmt_ij)      
    if handle is not None:
       handle.close()
   

--- a/examples-nosql-python-sdk/sqlexamples/TableJoins.py
+++ b/examples-nosql-python-sdk/sqlexamples/TableJoins.py
@@ -132,13 +132,13 @@ def main():
    insert_record(handle,'ticket.bagInfo',data2)
    insert_record(handle,'ticket.bagInfo.flightLegs',data3)
    sql_stmt_loj='SELECT * FROM ticket a LEFT OUTER JOIN ticket.bagInfo.flightLegs b ON a.ticketNo=b.ticketNo'
-   print('Fetching data using Left Outer Joins ')
+   print('Fetching data using Left Outer Join ')
    fetch_data(handle,sql_stmt_loj)
    sql_stmt_nt='SELECT * FROM NESTED TABLES (ticket a descendants(ticket.bagInfo.flightLegs b))'
    print('Fetching data using NESTED TABLES ')
    fetch_data(handle,sql_stmt_nt)
    sql_stmt_ij='SELECT * FROM ticket a, ticket.bagInfo.flightLegs b WHERE a.ticketNo=b.ticketNo'
-   print('Fetching data using Inner Joins ')
+   print('Fetching data using Inner Join ')
    fetch_data(handle,sql_stmt_ij)      
    if handle is not None:
       handle.close()


### PR DESCRIPTION
### examples-nosql-go-sdk, examples-nosql-java-sdk, examples-nosql-node-sdk, examples-nosql-python-sdk, examples-nosql-dotnet-sdk

### Changes:

- Included inner join statements in TableJoins file present in the sqlexamples folder of the following SDKs: Go, Java, Node.js, Python and .NET
- Performs inner join of the tables and prints the result set

### Please sign the request with your email
purnima.subramanian@oracle.com
